### PR TITLE
Removing folder from CMakeLists.txt for solving error in the building process

### DIFF
--- a/scout/scout_gazebo_sim/CMakeLists.txt
+++ b/scout/scout_gazebo_sim/CMakeLists.txt
@@ -21,7 +21,7 @@ find_package(ament_cmake REQUIRED)
 # further dependencies manually.
 # find_package(<dependency> REQUIRED)
 install(
-  DIRECTORY launch rviz worlds
+  DIRECTORY launch worlds
   DESTINATION share/${PROJECT_NAME}
 )
 if(BUILD_TESTING)


### PR DESCRIPTION
The rviz folder was not present in the folder tree of the scout_gazebo_sim package, by removing it I was able to run the building and the simulation.